### PR TITLE
Update service standard

### DIFF
--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -36,8 +36,8 @@
     <div class="govuk-grid-row">
 
       <div class="govuk-grid-column-one-third">
-        <h3 class="govuk-heading-m govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="{{ '/service-standards/' | url }}">Service standards</a></h3>
-        <p class="govuk-body-s">Check the standards you should follow and why they are important for all digital services in Defence.</p>
+        <h3 class="govuk-heading-m govuk-!-margin-bottom-2"><a class="govuk-link govuk-link--no-visited-state" href="{{ '/meet-the-standard/' | url }}">Meet the standard</a></h3>
+        <p class="govuk-body-s">Check why the GOV.UK Service Standard is important for all digital services in Defence.</p>
       </div>
 
       <div class="govuk-grid-column-one-third">

--- a/src/meet-the-standard/index.njk
+++ b/src/meet-the-standard/index.njk
@@ -20,9 +20,9 @@
 
     <div class="govuk-main-wrapper">
 
-      <div class="govuk-grid-row">
+     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Service standards</h1>
+          <h1 class="govuk-heading-xl">Meet the standard</h1>
         </div>
       </div>
 
@@ -32,7 +32,7 @@
 
           <p class="govuk-body">All teams creating digital services for Defence should meet the GOV.UK Service Standard. This applies to internal services as well as services for citizens.</p>
           
-          <p class="govuk-body">Service standards help you:</p>
+          <p class="govuk-body">The GOV.UK Service Standard helps you:</p>
 
           <ul class="govuk-body">
             <li>design the right thing for your users</li>
@@ -40,9 +40,9 @@
             <li>make the best recruitment and technology choices</li>
           </ul>
 
-          <h2 class="govuk-heading-l">Apply the service standards</h2>
+          <h2 class="govuk-heading-l">Apply the GOV.UK Service Standard</h2>
 
-          <p class="govuk-body">To meet service standards in Defence, check what makes Defence different from other government departments.</p> 
+        <p class="govuk-body">Check what makes Defence different from other government departments.</p> 
 
           {% set htmlAccordion1 %}
             <p class="govuk-body">You should test your service with real users in the place that they use it. In Defence, this is not always possible. Consider testing in a simulated environment or bringing a representative user into your design team.</p>


### PR DESCRIPTION
- make tile title singular
- add GOV.UK Service Standard to tile description
- improve the 'Apply...' sub-header
- make all references on 'Meet the standard' singular