### PR TITLE
Update assessor criteria

### DIFF
--- a/src/your-community/index.md
+++ b/src/your-community/index.md
@@ -46,4 +46,4 @@ This includes anyone who has just joined Defence but has digital experience in a
 
 If you meet these criteria, send your details to [assessments@digital.mod.uk](mailto:assessments@digital.mod.uk?subject=Service%20assessor%20training). 
 
-We would also like to hear from all trained assessors across Defence. 
+We would like to hear from trained assessors across Defence. You can join the panel for internal service assessments.

--- a/src/your-community/index.md
+++ b/src/your-community/index.md
@@ -40,9 +40,9 @@ You’ll also join the assessor community across government.
 
 ### Who can get training
 
-You need to be a crown servant in Defence who has been in a digital role for at least 6 months. 
+You need to be a crown servant in Defence who has worked on a digital service for at least 6 months. 
 
-This includes anyone who has just joined Defence but has experience in a digital role in another government department.  
+This includes anyone who has just joined Defence but has digital experience in another government department.   
 
 If you meet these criteria, send your details to [assessments@digital.mod.uk](mailto:assessments@digital.mod.uk?subject=Service%20assessor%20training). 
 


### PR DESCRIPTION
Improved 'in a digital role' to 'worked on a digital service' and 'has digital experience'.

This now covers people with military titles.